### PR TITLE
Update BookLanguage.kt

### DIFF
--- a/app/src/main/java/com/cis/wsreader/helpers/book/BookLanguage.kt
+++ b/app/src/main/java/com/cis/wsreader/helpers/book/BookLanguage.kt
@@ -40,4 +40,16 @@ sealed class BookLanguage(val name: String, val isoCode: String) {
     @Keep
     data object Telugu : BookLanguage("Telugu", "te")
 
+    @Keep
+    data object Indonesia : BookLanguage("Indonesia", "id")
+
+    @Keep
+    data object Sunda : BookLanguage("Sunda", "su")
+
+    @Keep
+    data object Java : BookLanguage("Java", "jv")
+
+    @Keep
+    data object Bali : BookLanguage("Bali", "ban")
+
 }


### PR DESCRIPTION
add Indonesian, Javanese, Balinese, and Sundanese Wikisource. 

Please add Indonesian Wikisource (https://id.wikisource.org/), Balinese Wikisource (https://jv.wikisource.org/), Sundanese Wikisource (https://su.wikisource.org/) and Javanese Wikisource (https://ban.wikisource.org/) in this app. 

This is a query for Wikidata Item in Indonesian Wikisource: w.wiki/D6ug

Item in Balinese Wikisource (https://jv.wikisource.org/), Sundanese Wikisource (https://su.wikisource.org/) and Javanese Wikisource (https://ban.wikisource.org/) still on going